### PR TITLE
refactor: seperate domain model and entity model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 ## 항해 플러스와 함께하는 역량 강화 프로젝트
+
+### Intro
+
+> CI/CD, TDD, DDD, 모니터링 시스템, 장애 대응을 공부하면서 적용해보기 위한 레포지토리
+
+### Initialize
+
+```bash
+$ git clone https://github.com/EnhancementPlayGround/nest_playground.git
+$ cd nest_playground
+$ npm install
+$ docker compose up --build server
+```
+
+### Tech Stack
+
+| Name       |      Description      |
+| ---------- | :-------------------: |
+| Node.js    |  자바스크립트 런타임  |
+| TypeScript |     타입스크립트      |
+| Nest.js    |     웹 프레임워크     |
+| MySQL      |          DB           |
+| TypeORM    |          ORM          |
+| Docker     |     컨테이너 관리     |
+| ECS        | AWS Container Service |
+| CloudWatch |    모니터링 시스템    |
+| SonarCloud |    코드 품질 관리     |
+| Jest       |        테스트         |
+| Github     |       형상관리        |
+
+### Project Structure
+
+```bash
+.
+├── src
+│   ├── main.ts
+│   ├── @types
+│   ├── config
+│   ├── libs
+│   ├── middlewares
+│   ├── migrations
+│   ├── services
+│   |   ├── 각 도메인별 폴더
+│   |   |   ├── presentation
+│   |   |   ├── application
+│   |   |   ├── domain
+│   |   |   ├── infrastructure
+│   |   |   ├── dto
+│   |   |   └── module.ts
+```

--- a/src/config/ormconfig.ts
+++ b/src/config/ormconfig.ts
@@ -19,7 +19,7 @@ export const ormconfig = {
     synchronize: false,
     // migrations: ['src/migration/**/*.ts'],
     supportBigNumbers: true,
-    entities: [join(__dirname, '..', 'services', '**', 'domain', 'model.{ts,js}'), DomainEvent],
+    entities: [join(__dirname, '..', 'services', '**', 'infrastructure', 'entity.{ts,js}'), DomainEvent],
     bigNumberStrings: false,
   },
   development: {
@@ -27,7 +27,7 @@ export const ormconfig = {
     synchronize: true,
     // migrations: ['dist/src/migrations/*.js'],
     supportBigNumbers: true,
-    entities: [join(__dirname, '..', 'services', '**', 'domain', 'model.{ts,js}'), DomainEvent],
+    entities: [join(__dirname, '..', 'services', '**', 'infrastructure', 'entity.{ts,js}'), DomainEvent],
     bigNumberStrings: false,
     logging: true,
   },
@@ -41,7 +41,7 @@ export const ormconfig = {
     synchronize: false,
     migrations: ['src/migrations/*{.ts,.js}'],
     supportBigNumbers: true,
-    entities: [join(__dirname, '..', 'services', '**', 'domain', 'model.{ts,js}'), DomainEvent],
+    entities: [join(__dirname, '..', 'services', '**', 'infrastructure', 'entity.{ts,js}'), DomainEvent],
     bigNumberStrings: false,
   },
   $default: {
@@ -49,7 +49,7 @@ export const ormconfig = {
     synchronize: false,
     migrations: ['dist/src/migrations/*.js'],
     supportBigNumbers: true,
-    entities: [join(__dirname, '..', 'services', '**', 'domain', 'model.{ts,js}'), DomainEvent],
+    entities: [join(__dirname, '..', 'services', '**', 'infrastructure', 'entity.{ts,js}'), DomainEvent],
     bigNumberStrings: false,
   },
 };

--- a/src/libs/ddd/aggregate.ts
+++ b/src/libs/ddd/aggregate.ts
@@ -1,16 +1,7 @@
 import { Exclude } from 'class-transformer';
-import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 import { DomainEvent } from './event';
 
 export abstract class Aggregate {
-  @CreateDateColumn()
-  @Exclude()
-  private createdAt!: Date;
-
-  @UpdateDateColumn()
-  @Exclude()
-  private updatedAt!: Date;
-
   @Exclude()
   private events: DomainEvent[] = [];
 
@@ -24,7 +15,6 @@ export abstract class Aggregate {
 }
 
 export class VersionedAggregate extends Aggregate {
-  @VersionColumn({ default: 1 })
   @Exclude()
   version!: number;
 }

--- a/src/libs/ddd/base-entity.ts
+++ b/src/libs/ddd/base-entity.ts
@@ -1,0 +1,18 @@
+import { Exclude } from 'class-transformer';
+import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
+
+export abstract class BaseEntity {
+  @CreateDateColumn()
+  @Exclude()
+  private createdAt!: Date;
+
+  @UpdateDateColumn()
+  @Exclude()
+  private updatedAt!: Date;
+}
+
+export abstract class VersionedEntity extends BaseEntity {
+  @VersionColumn({ default: 1 })
+  @Exclude()
+  version!: number;
+}

--- a/src/libs/ddd/index.ts
+++ b/src/libs/ddd/index.ts
@@ -1,3 +1,4 @@
 export * from './aggregate';
+export * from './base-entity';
 export * from './repository';
 export * from './service';

--- a/src/libs/ddd/repository.ts
+++ b/src/libs/ddd/repository.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { EntityManager, ObjectType } from 'typeorm';
 import { EventEmitter2 as EventEmitter } from '@nestjs/event-emitter';
-import { optimisticLockVersionMismatch } from '../exceptions';
 import { DomainEvent } from './event';
-import { Aggregate, VersionedAggregate } from './aggregate';
+import { Aggregate } from './aggregate';
+import { BaseEntity } from './base-entity';
 
 @Injectable()
-export abstract class Repository<T extends Aggregate> {
+export abstract class Repository<T extends BaseEntity> {
   protected abstract entityClass: ObjectType<T>;
 
   constructor(private entityManager: EntityManager, private eventEmitter: EventEmitter) {}
@@ -15,46 +15,12 @@ export abstract class Repository<T extends Aggregate> {
     return this.entityManager;
   }
 
-  async save(args: { target: T[]; transactionalEntityManager?: EntityManager }) {
-    await (args.transactionalEntityManager ?? this.getManager()).save(args.target);
-    await this.saveEvent({
-      events: args.target.flatMap((entity) => entity.getPublishedEvents()),
-      transactionalEntityManager: args.transactionalEntityManager,
-    });
-  }
+  abstract save(args: { target: Aggregate[]; transactionalEntityManager?: EntityManager }): Promise<void>;
 
   async saveEvent(args: { events: DomainEvent[]; transactionalEntityManager?: EntityManager }) {
     await (args.transactionalEntityManager ?? this.getManager()).save(DomainEvent, args.events);
     await Promise.all(args.events.map((event) => this.eventEmitter.emit(event.type, event)));
   }
 
-  async remove(args: { target: T[]; transactionalEntityManager?: EntityManager }) {
-    await (args.transactionalEntityManager ?? this.getManager()).remove(args.target);
-  }
-}
-
-@Injectable()
-export abstract class VersionedRepository<T extends VersionedAggregate> extends Repository<T> {
-  protected abstract entityClass: ObjectType<T>;
-
-  async save(args: { target: T[]; transactionalEntityManager?: EntityManager }) {
-    const entityVersionOf = args.target.reduce((acc, entity) => {
-      // @ts-expect-error
-      acc[entity.id.toString()] = entity.version;
-      return acc;
-    }, {} as Record<string, number>);
-    await super.save({ target: args.target, transactionalEntityManager: args.transactionalEntityManager });
-
-    args.target
-      .filter((entity) => entity.version > 1) // version === 1 이면 새로 생성한 entity 이므로 버젼 체크 할 필요 없음
-      .forEach((entity) => {
-        // @ts-expect-error
-        if (entity.version !== entityVersionOf[entity.id.toString()] + 1) {
-          // @ts-expect-error
-          throw optimisticLockVersionMismatch(`${entity.constructor.name}(${entity.id})'s version is mismatched.`, {
-            errorMessage: "Something went wrong and we couldn't complete your request.",
-          });
-        }
-      });
-  }
+  abstract remove(args: { target: Aggregate[]; transactionalEntityManager?: EntityManager }): Promise<void>;
 }

--- a/src/services/accounts/domain/model.ts
+++ b/src/services/accounts/domain/model.ts
@@ -1,29 +1,24 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { nanoid } from 'nanoid';
-import { Aggregate } from '@libs/ddd';
 import { badRequest } from '@libs/exceptions';
+import { Aggregate } from '@libs/ddd';
+import { AccountEntity } from '../infrastructure/entity';
 
 const transactionType = ['order'] as const;
 export type TransactionType = (typeof transactionType)[number];
 
-@Entity()
-@Index('Idx_userId', ['userId'])
 export class Account extends Aggregate {
-  @PrimaryColumn()
   id!: string;
 
-  @Column()
   userId!: string;
 
-  @Column()
   balance!: number;
 
-  constructor(args: { userId: string }) {
+  constructor(args: { id?: string; userId: string; balance?: number }) {
     super();
     if (args) {
-      this.id = nanoid();
+      this.id = args.id ?? nanoid();
       this.userId = args.userId;
-      this.balance = 0;
+      this.balance = args.balance ?? 0;
     }
   }
 
@@ -39,5 +34,13 @@ export class Account extends Aggregate {
     }
 
     this.balance -= amount;
+  }
+
+  static of(args: { id?: string; userId: string; balance?: number }) {
+    return new Account(args);
+  }
+
+  toEntity() {
+    return new AccountEntity(this);
   }
 }

--- a/src/services/accounts/infrastructure/entity.ts
+++ b/src/services/accounts/infrastructure/entity.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
-import { BaseEntity } from '../../../libs/ddd/base-entity';
+import { BaseEntity } from '@libs/ddd';
 
 @Entity('account')
 @Index('Idx_userId', ['userId'])

--- a/src/services/accounts/infrastructure/entity.ts
+++ b/src/services/accounts/infrastructure/entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { BaseEntity } from '../../../libs/ddd/base-entity';
+
+@Entity('account')
+@Index('Idx_userId', ['userId'])
+export class AccountEntity extends BaseEntity {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  balance!: number;
+
+  constructor(args: { userId: string; id: string; balance?: number }) {
+    super();
+    if (args) {
+      this.id = args.id;
+      this.userId = args.userId;
+      this.balance = args.balance ?? 0;
+    }
+  }
+
+  static of(args: { userId: string; id: string; balance?: number }) {
+    return new AccountEntity(args);
+  }
+}

--- a/src/services/accounts/infrastructure/repository.ts
+++ b/src/services/accounts/infrastructure/repository.ts
@@ -2,23 +2,37 @@ import { Injectable } from '@nestjs/common';
 import type { EntityManager } from 'typeorm';
 import { Repository } from '@libs/ddd';
 import { FindOptions, convertOptions } from '@libs/orm';
+import { AccountEntity } from './entity';
 import { Account } from '../domain/model';
 
 @Injectable()
-export class AccountRepository extends Repository<Account> {
-  entityClass = Account;
+export class AccountRepository extends Repository<AccountEntity> {
+  entityClass = AccountEntity;
+
+  async save(args: { target: Account[]; transactionalEntityManager?: EntityManager }) {
+    const entities = args.target.map(AccountEntity.of);
+    await (args.transactionalEntityManager ?? this.getManager()).save(entities);
+    await this.saveEvent({ events: args.target.flatMap((account) => account.getPublishedEvents()) });
+  }
+
+  async remove(args: { target: Account[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+    const entities = args.target.map(AccountEntity.of);
+    await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
+  }
 
   async find(args: {
     conditions: { userId?: string };
     options?: FindOptions;
     transactionalEntityManager?: EntityManager;
   }) {
-    return (args.transactionalEntityManager ?? this.getManager()).find(Account, {
+    const entities = await (args.transactionalEntityManager ?? this.getManager()).find(AccountEntity, {
       where: {
         userId: args.conditions.userId,
       },
       ...convertOptions(args.options),
     });
+
+    return entities.map(Account.of);
   }
 
   async findOneOrFail(args: {
@@ -26,15 +40,13 @@ export class AccountRepository extends Repository<Account> {
     options?: FindOptions;
     transactionalEntityManager?: EntityManager;
   }): Promise<Account> {
-    return (args.transactionalEntityManager ?? this.getManager()).findOneOrFail(Account, {
+    const entity = await (args.transactionalEntityManager ?? this.getManager()).findOneOrFail(AccountEntity, {
       where: {
         userId: args.conditions.userId,
       },
       ...convertOptions(args.options),
     });
-  }
 
-  async truncate() {
-    await this.getManager().clear(Account);
+    return Account.of(entity);
   }
 }

--- a/src/services/accounts/infrastructure/repository.ts
+++ b/src/services/accounts/infrastructure/repository.ts
@@ -15,7 +15,7 @@ export class AccountRepository extends Repository<AccountEntity> {
     await this.saveEvent({ events: args.target.flatMap((account) => account.getPublishedEvents()) });
   }
 
-  async remove(args: { target: Account[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+  async remove(args: { target: Account[]; transactionalEntityManager?: EntityManager }): Promise<void> {
     const entities = args.target.map(AccountEntity.of);
     await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
   }

--- a/src/services/order-product-logs/domain/model.ts
+++ b/src/services/order-product-logs/domain/model.ts
@@ -1,27 +1,18 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { Aggregate } from '@libs/ddd';
 
-@Entity()
 export class OrderProductLog extends Aggregate {
-  @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column()
   orderId!: string;
 
-  @Column()
   userId!: string;
 
-  @Column()
   productId!: string;
 
-  @Column()
   quantity!: number;
 
-  @Column()
   price!: number;
 
-  @Column()
   occurredAt!: Date;
 
   constructor(args: { orderId: string; userId: string; productId: string; quantity: number; price: number }) {

--- a/src/services/order-product-logs/infrastructure/entity.ts
+++ b/src/services/order-product-logs/infrastructure/entity.ts
@@ -1,0 +1,52 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity } from '@libs/ddd';
+
+type CtorType = {
+  id: number;
+  orderId: string;
+  userId: string;
+  productId: string;
+  quantity: number;
+  price: number;
+  occurredAt: Date;
+};
+@Entity('order_product_log')
+export class OrderProductLogEntity extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  orderId!: string;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  productId!: string;
+
+  @Column()
+  quantity!: number;
+
+  @Column()
+  price!: number;
+
+  @Column()
+  occurredAt!: Date;
+
+  constructor(args: CtorType) {
+    super();
+    if (args) {
+      this.id = args.id;
+      this.orderId = args.orderId;
+      this.userId = args.userId;
+      this.productId = args.productId;
+      this.quantity = args.quantity;
+      this.price = args.price;
+      this.occurredAt = args.occurredAt;
+    }
+  }
+
+  static of(args: CtorType) {
+    return new OrderProductLogEntity(args);
+  }
+}

--- a/src/services/order-product-logs/infrastructure/repository.ts
+++ b/src/services/order-product-logs/infrastructure/repository.ts
@@ -14,10 +14,7 @@ export class OrderProductLogRepository extends Repository<OrderProductLogEntity>
     await this.saveEvent({ events: args.target.flatMap((log) => log.getPublishedEvents()) });
   }
 
-  async remove(args: {
-    target: OrderProductLog[];
-    transactionalEntityManager?: EntityManager | undefined;
-  }): Promise<void> {
+  async remove(args: { target: OrderProductLog[]; transactionalEntityManager?: EntityManager }): Promise<void> {
     const entities = args.target.map(OrderProductLogEntity.of);
     await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
   }

--- a/src/services/orders/domain/model.ts
+++ b/src/services/orders/domain/model.ts
@@ -7,6 +7,7 @@ import type { Product } from '../../products/domain/model';
 import { OrderPaidEvent } from './events';
 
 type CtorType = {
+  id?: string;
   userId: string;
   totalAmount: number;
   lines: {
@@ -37,7 +38,7 @@ export class Order extends Aggregate {
   constructor(args: CtorType) {
     super();
     if (args) {
-      this.id = nanoid();
+      this.id = args.id ?? nanoid();
       this.userId = args.userId;
       this.totalAmount = args.totalAmount;
       this.lines = args.lines.map((line) => new OrderLine(line));
@@ -59,6 +60,10 @@ export class Order extends Aggregate {
       lines,
       totalAmount,
     });
+  }
+
+  static of(args: CtorType) {
+    return new Order(args);
   }
 
   // NOTE: 현재는 status가 필요없기 때문에 이렇게 구현했지만 실제로는 status가 필요할 것이다.

--- a/src/services/orders/infrastructure/entity.ts
+++ b/src/services/orders/infrastructure/entity.ts
@@ -1,0 +1,78 @@
+import { Column, DeleteDateColumn, Entity, ManyToOne, OneToMany, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { Exclude } from 'class-transformer';
+import { BaseEntity } from '@libs/ddd';
+
+type CtorType = {
+  id: string;
+  userId: string;
+  totalAmount: number;
+  lines: {
+    productId: string;
+    price: number;
+    quantity: number;
+  }[];
+};
+
+@Entity('order')
+export class OrderEntity extends BaseEntity {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  userId!: string;
+
+  @Column()
+  totalAmount!: number;
+
+  @OneToMany(() => OrderLineEntity, (orderLine) => orderLine.order, { cascade: true, eager: true })
+  lines!: OrderLineEntity[];
+
+  @DeleteDateColumn({ nullable: true })
+  @Exclude()
+  deletedAt!: Date;
+
+  constructor(args: CtorType) {
+    super();
+    if (args) {
+      this.id = args.id;
+      this.userId = args.userId;
+      this.totalAmount = args.totalAmount;
+      this.lines = args.lines.map((line) => new OrderLineEntity(line));
+    }
+  }
+
+  static of(args: CtorType) {
+    return new OrderEntity(args);
+  }
+}
+
+@Entity('order_line')
+export class OrderLineEntity {
+  @PrimaryGeneratedColumn()
+  @Exclude()
+  id!: string;
+
+  @Column()
+  productId!: string;
+
+  @Column()
+  price!: number;
+
+  @Column()
+  quantity!: number;
+
+  @DeleteDateColumn({ nullable: true })
+  @Exclude()
+  deletedAt!: Date;
+
+  @ManyToOne(() => OrderEntity, (order) => order.lines)
+  order!: never;
+
+  constructor(args: { productId: string; price: number; quantity: number }) {
+    if (args) {
+      this.productId = args.productId;
+      this.price = args.price;
+      this.quantity = args.quantity;
+    }
+  }
+}

--- a/src/services/orders/infrastructure/repository.ts
+++ b/src/services/orders/infrastructure/repository.ts
@@ -19,7 +19,7 @@ export class OrderRepository extends Repository<OrderEntity> {
     });
   }
 
-  async remove(args: { target: Order[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+  async remove(args: { target: Order[]; transactionalEntityManager?: EntityManager }): Promise<void> {
     const entities = args.target.map(OrderEntity.of);
     await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
   }

--- a/src/services/orders/infrastructure/repository.ts
+++ b/src/services/orders/infrastructure/repository.ts
@@ -4,12 +4,27 @@ import { Repository } from '@libs/ddd';
 import { internalServerError } from '@libs/exceptions';
 import { convertOptions, InValues, type FindOptions } from '@libs/orm';
 import { Order } from '../domain/model';
+import { OrderEntity } from './entity';
 
 @Injectable()
-export class OrderRepository extends Repository<Order> {
-  entityClass = Order;
+export class OrderRepository extends Repository<OrderEntity> {
+  entityClass = OrderEntity;
 
-  async sendToDataPlatform(args: { order: Order }) {
+  async save(args: { target: Order[]; transactionalEntityManager?: EntityManager }) {
+    const entities = args.target.map(OrderEntity.of);
+    await (args.transactionalEntityManager ?? this.getManager()).save(entities);
+    await this.saveEvent({
+      events: args.target.flatMap((entity) => entity.getPublishedEvents()),
+      transactionalEntityManager: args.transactionalEntityManager,
+    });
+  }
+
+  async remove(args: { target: Order[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+    const entities = args.target.map(OrderEntity.of);
+    await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
+  }
+
+  async sendToDataPlatform(_: { order: Order }) {
     if (Math.random() < 0.01) {
       throw internalServerError('Failed to send order to data platform.', {
         errorMessage: "Something went wrong and we couldn't complete your request.",
@@ -22,15 +37,18 @@ export class OrderRepository extends Repository<Order> {
     options?: FindOptions;
     transactionalEntityManager?: EntityManager;
   }) {
-    return (args.transactionalEntityManager ?? this.getManager()).find(Order, {
+    const entities = await (args.transactionalEntityManager ?? this.getManager()).find(OrderEntity, {
       where: {
         id: InValues(args.conditions.ids),
       },
       ...convertOptions(args.options),
     });
+
+    return entities.map(Order.of);
   }
 
   async softDelete(args: { target: Order[]; transactionalEntityManager?: EntityManager }) {
-    return (args.transactionalEntityManager ?? this.getManager()).softRemove(args.target);
+    const entities = args.target.map(OrderEntity.of);
+    return (args.transactionalEntityManager ?? this.getManager()).softRemove(entities);
   }
 }

--- a/src/services/products/domain/model.ts
+++ b/src/services/products/domain/model.ts
@@ -1,20 +1,30 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { VersionedAggregate } from '@libs/ddd';
 import { badRequest } from '@libs/exceptions';
+import { nanoid } from 'nanoid';
 
-@Entity()
 export class Product extends VersionedAggregate {
-  @PrimaryColumn()
   id!: string;
 
-  @Column()
   name!: string;
 
-  @Column()
   price!: number;
 
-  @Column()
   stock!: number;
+
+  constructor(args: { id?: string; name: string; price: number; stock: number; version?: number }) {
+    super();
+    if (args) {
+      this.id = args.id ?? nanoid();
+      this.name = args.name;
+      this.price = args.price;
+      this.stock = args.stock;
+      this.version = args.version ?? 1;
+    }
+  }
+
+  static of(args: { id?: string; name: string; price: number; stock: number; version: number }) {
+    return new Product(args);
+  }
 
   ordered({ quantity }: { quantity: number }) {
     if (quantity > this.stock)

--- a/src/services/products/infrastructure/entity.ts
+++ b/src/services/products/infrastructure/entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { VersionedEntity } from '@libs/ddd';
+
+@Entity('product')
+export class ProductEntity extends VersionedEntity {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @Column()
+  price!: number;
+
+  @Column()
+  stock!: number;
+
+  constructor(args: { id: string; name: string; price: number; stock: number; version: number }) {
+    super();
+    if (args) {
+      this.id = args.id;
+      this.name = args.name;
+      this.price = args.price;
+      this.stock = args.stock;
+      this.version = args.version;
+    }
+  }
+
+  static of(args: { id: string; name: string; price: number; stock: number; version: number }) {
+    return new ProductEntity(args);
+  }
+}

--- a/src/services/products/infrastructure/repository.ts
+++ b/src/services/products/infrastructure/repository.ts
@@ -1,27 +1,59 @@
 import { Injectable } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
-import { VersionedRepository } from '@libs/ddd';
+import { Repository } from '@libs/ddd';
 import { FindOptions, InValues, convertOptions } from '@libs/orm';
+import { optimisticLockVersionMismatch } from '@libs/exceptions';
+import { ProductEntity } from './entity';
 import { Product } from '../domain/model';
 
 @Injectable()
-export class ProductRepository extends VersionedRepository<Product> {
-  entityClass = Product;
+export class ProductRepository extends Repository<ProductEntity> {
+  entityClass = ProductEntity;
+
+  async save(args: { target: Product[]; transactionalEntityManager?: EntityManager }) {
+    const entities = args.target.map(ProductEntity.of);
+    const entityVersionOf = entities.reduce((acc, entity) => {
+      acc[entity.id.toString()] = entity.version;
+      return acc;
+    }, {} as Record<string, number>);
+
+    await (args.transactionalEntityManager ?? this.getManager()).save(entities, { reload: true });
+    await this.saveEvent({
+      events: args.target.flatMap((entity) => entity.getPublishedEvents()),
+      transactionalEntityManager: args.transactionalEntityManager,
+    });
+
+    entities
+      .filter((entity) => entity.version > 1) // version === 1 이면 새로 생성한 entity 이므로 버젼 체크 할 필요 없음
+      .forEach((entity) => {
+        if (entity.version !== entityVersionOf[entity.id.toString()] + 1) {
+          throw optimisticLockVersionMismatch(
+            `${entity.constructor.name}(${entity.id})'s version(${entity.version}) is mismatched.`,
+            {
+              errorMessage: "Something went wrong and we couldn't complete your request.",
+            },
+          );
+        }
+      });
+  }
+
+  async remove(args: { target: Product[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+    const entities = args.target.map(ProductEntity.of);
+    await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
+  }
 
   async find(args: {
     conditions: { ids?: string[] };
     options?: FindOptions;
     transactionalEntityManager?: EntityManager;
   }) {
-    return (args.transactionalEntityManager ?? this.getManager()).find(Product, {
+    const entities = await (args.transactionalEntityManager ?? this.getManager()).find(ProductEntity, {
       where: {
         id: InValues(args.conditions.ids),
       },
       ...convertOptions(args.options),
     });
-  }
 
-  async truncate() {
-    await this.getManager().clear(Product);
+    return entities.map(Product.of);
   }
 }

--- a/src/services/products/infrastructure/repository.ts
+++ b/src/services/products/infrastructure/repository.ts
@@ -37,7 +37,7 @@ export class ProductRepository extends Repository<ProductEntity> {
       });
   }
 
-  async remove(args: { target: Product[]; transactionalEntityManager?: EntityManager | undefined }): Promise<void> {
+  async remove(args: { target: Product[]; transactionalEntityManager?: EntityManager }): Promise<void> {
     const entities = args.target.map(ProductEntity.of);
     await (args.transactionalEntityManager ?? this.getManager()).remove(entities);
   }

--- a/src/services/users/domain/model.ts
+++ b/src/services/users/domain/model.ts
@@ -1,19 +1,15 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { nanoid } from 'nanoid';
 import { Aggregate } from '@libs/ddd';
 
-@Entity()
 export class User extends Aggregate {
-  @PrimaryColumn()
   id!: string;
 
-  @Column()
   name!: string;
 
-  constructor(args: { name: string }) {
+  constructor(args: { id?: string; name: string }) {
     super();
     if (args) {
-      this.id = nanoid();
+      this.id = args.id ?? nanoid();
       this.name = args.name;
     }
   }

--- a/src/services/users/infrastructure/entity.ts
+++ b/src/services/users/infrastructure/entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { nanoid } from 'nanoid';
+import { BaseEntity } from '@libs/ddd';
+
+@Entity('user')
+export class UserEntity extends BaseEntity {
+  @PrimaryColumn()
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  constructor(args: { name: string }) {
+    super();
+    if (args) {
+      this.id = nanoid();
+      this.name = args.name;
+    }
+  }
+}

--- a/test/services/accounts/application/integration.test.ts
+++ b/test/services/accounts/application/integration.test.ts
@@ -31,25 +31,26 @@ describe('Account Service integration test', () => {
   });
 
   describe('getList test', () => {
+    const testAccounts = [
+      plainToClass(Account, {
+        id: 'accountTest1',
+        userId: 'accountTest1',
+        balance: 1000,
+      }),
+      plainToClass(Account, {
+        id: 'accountTest2',
+        userId: 'accountTest1',
+        balance: 2000,
+      }),
+    ];
     beforeAll(async () => {
       await accountRepository.save({
-        target: [
-          plainToClass(Account, {
-            id: 'accountTest1',
-            userId: 'accountTest1',
-            balance: 1000,
-          }),
-          plainToClass(Account, {
-            id: 'accountTest2',
-            userId: 'accountTest1',
-            balance: 2000,
-          }),
-        ],
+        target: testAccounts,
       });
     });
 
     afterAll(async () => {
-      await accountRepository.truncate();
+      await accountRepository.remove({ target: testAccounts });
     });
 
     test('어카운트 list를 조회한다.', async () => {

--- a/test/services/orders/application/integration.test.ts
+++ b/test/services/orders/application/integration.test.ts
@@ -13,10 +13,10 @@ import { ProductModule } from '../../../../src/services/products/module';
 import { OrderRepository } from '../../../../src/services/orders/infrastructure/repository';
 import { AccountRepository } from '../../../../src/services/accounts/infrastructure/repository';
 import { ProductRepository } from '../../../../src/services/products/infrastructure/repository';
-import { Product } from '../../../../src/services/products/domain/model';
 import { Account } from '../../../../src/services/accounts/domain/model';
 import { CalculateOrderService } from '../../../../src/services/orders/domain/services';
 import { AccountModule } from '../../../../src/services/accounts/module';
+import { Product } from '../../../../src/services/products/domain/model';
 
 jest.mock('nanoid');
 


### PR DESCRIPTION
### 개발내용
- 도메인과 엔티티 모델 분리
  - 분리하면서 orm에 대한 의존도를 낮춘다.
- 추상화 클래스인 Repository의 save, remove를 추상화 method로 변경
- `VersionedRepository` 삭제