### PR TITLE
entity id 변경

### DIFF
--- a/src/migrations/1703295509011-time.ts
+++ b/src/migrations/1703295509011-time.ts
@@ -9,7 +9,7 @@ export class Time1703295509011 implements MigrationInterface {
       'CREATE TABLE IF NOT EXISTS `product` (`createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `version` int NOT NULL DEFAULT "1", `id` varchar(255) NOT NULL, `name` varchar(255) NOT NULL, `price` int NOT NULL, `stock` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB;',
     );
     await queryRunner.query(
-      'CREATE TABLE IF NOT EXISTS `account` (`createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `id` varchar(255) NOT NULL, `userId` varchar(255) NOT NULL, `balance` int NOT NULL, INDEX `Idx_userId` (`userId`), PRIMARY KEY (`id`)) ENGINE=InnoDB;',
+      'CREATE TABLE `account` (`createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `id` int NOT NULL AUTO_INCREMENT, `userId` varchar(255) NOT NULL, `balance` int NOT NULL, `uniquenessKey` varchar(255) NOT NULL, INDEX `Idx_userId` (`userId`), UNIQUE INDEX `IDX_35ecb03568c689a4a28151df0c` (`uniquenessKey`), PRIMARY KEY (`id`)) ENGINE=InnoDB;',
     );
     await queryRunner.query(
       'CREATE TABLE IF NOT EXISTS `order` (`createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `id` varchar(255) NOT NULL, `userId` varchar(255) NOT NULL, `totalAmount` int NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB;',

--- a/src/services/accounts/domain/model.ts
+++ b/src/services/accounts/domain/model.ts
@@ -13,12 +13,15 @@ export class Account extends Aggregate {
 
   balance!: number;
 
-  constructor(args: { id?: string; userId: string; balance?: number }) {
+  index?: number;
+
+  constructor(args: { id?: number; userId: string; balance?: number; uniquenessKey?: string }) {
     super();
     if (args) {
-      this.id = args.id ?? nanoid();
+      this.id = args.uniquenessKey ?? nanoid();
       this.userId = args.userId;
       this.balance = args.balance ?? 0;
+      this.index = args.id;
     }
   }
 
@@ -36,7 +39,7 @@ export class Account extends Aggregate {
     this.balance -= amount;
   }
 
-  static of(args: { id?: string; userId: string; balance?: number }) {
+  static of(args: { id: number; userId: string; balance?: number; uniquenessKey?: string }) {
     return new Account(args);
   }
 

--- a/src/services/accounts/infrastructure/entity.ts
+++ b/src/services/accounts/infrastructure/entity.ts
@@ -1,11 +1,11 @@
-import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 import { BaseEntity } from '@libs/ddd';
 
 @Entity('account')
 @Index('Idx_userId', ['userId'])
 export class AccountEntity extends BaseEntity {
-  @PrimaryColumn()
-  id!: string;
+  @PrimaryGeneratedColumn()
+  id!: number;
 
   @Column()
   userId!: string;
@@ -13,16 +13,21 @@ export class AccountEntity extends BaseEntity {
   @Column()
   balance!: number;
 
-  constructor(args: { userId: string; id: string; balance?: number }) {
+  @Column({ unique: true })
+  uniquenessKey!: string;
+
+  constructor(args: { userId: string; id: string; balance?: number; index?: number }) {
     super();
     if (args) {
-      this.id = args.id;
+      // @ts-expect-error FIXME: id는 처음 생성시에 존재하지 않으나 이후에는 존재하기 때문에 이렇게 일단 처리한다.
+      this.id = args.index;
       this.userId = args.userId;
       this.balance = args.balance ?? 0;
+      this.uniquenessKey = args.id;
     }
   }
 
-  static of(args: { userId: string; id: string; balance?: number }) {
+  static of(args: { userId: string; id: string; balance?: number; index?: number }) {
     return new AccountEntity(args);
   }
 }

--- a/test/services/accounts/account.e2e-test.ts
+++ b/test/services/accounts/account.e2e-test.ts
@@ -55,7 +55,9 @@ describe('Account E2E test', () => {
     });
 
     afterAll(async () => {
-      await repository.remove({ target: testAccounts });
+      const [target1] = await repository.find({ conditions: { userId: 'e2eAccountTest1' } });
+      const [target2] = await repository.find({ conditions: { userId: 'e2eAccountTest2' } });
+      await repository.remove({ target: [target1, target2] });
     });
 
     test('userId로 account list를 조회한다.', async () => {
@@ -87,7 +89,9 @@ describe('Account E2E test', () => {
     });
 
     afterAll(async () => {
-      await repository.remove({ target: testAccounts });
+      const [target1] = await repository.find({ conditions: { userId: 'e2eAccountTest1' } });
+      const [target2] = await repository.find({ conditions: { userId: 'e2eAccountTest2' } });
+      await repository.remove({ target: [target1, target2] });
     });
 
     test('account의 잔액을 충전한다. - 단일 request', async () => {

--- a/test/services/accounts/application/integration.test.ts
+++ b/test/services/accounts/application/integration.test.ts
@@ -50,7 +50,8 @@ describe('Account Service integration test', () => {
     });
 
     afterAll(async () => {
-      await accountRepository.remove({ target: testAccounts });
+      const target = await accountRepository.find({ conditions: { userId: 'accountTest1' } });
+      await accountRepository.remove({ target });
     });
 
     test('어카운트 list를 조회한다.', async () => {
@@ -90,7 +91,8 @@ describe('Account Service integration test', () => {
     });
 
     afterAll(async () => {
-      await accountRepository.remove({ target: testAccounts });
+      const target = await accountRepository.find({ conditions: { userId: 'accountTest1' } });
+      await accountRepository.remove({ target });
     });
 
     test('어카운트의 잔액을 충전한다', async () => {

--- a/test/services/orders/application/integration.test.ts
+++ b/test/services/orders/application/integration.test.ts
@@ -95,7 +95,8 @@ describe('Order Service integration test', () => {
       await orderRepository.getManager().query('DELETE FROM `order`');
       await orderRepository.getManager().query('ALTER TABLE `order` AUTO_INCREMENT = 1');
       await productRepository.remove({ target: testProducts });
-      await accountRepository.remove({ target: testAccounts });
+      const target = await accountRepository.find({ conditions: { userId: 'orderTest1' } });
+      await accountRepository.remove({ target });
     });
 
     test('주문을 생성하고 재고 차감, account 출금을 한다.', async () => {

--- a/test/services/orders/order.e2e-test.ts
+++ b/test/services/orders/order.e2e-test.ts
@@ -90,7 +90,8 @@ describe('Order E2E test', () => {
 
     afterAll(async () => {
       await productRepository.remove({ target: testProducts });
-      await accountRepository.remove({ target: testAccounts });
+      const target = await accountRepository.find({ conditions: { userId: 'e2eOrderTest1' } });
+      await accountRepository.remove({ target });
       await orderRepository.getManager().query('DELETE FROM `order_line`');
       await orderRepository.getManager().query('DELETE FROM `order`');
       await orderRepository.getManager().query('ALTER TABLE `order` AUTO_INCREMENT = 1');


### PR DESCRIPTION
mysql에서 pk를 uuid같은 랜덤한 걸로 했을 경우 성능에 큰 문제가 있을 수 있다.

- 엔티티 id는 auto inc로 변경, uniquenessKey 추가
- 도메인 모델 id는 그대로 string으로 -> entity의 uniquenessKey